### PR TITLE
Add autodetection for L530 and P110

### DIFF
--- a/homeassistant/components/tplink/manifest.json
+++ b/homeassistant/components/tplink/manifest.json
@@ -163,6 +163,14 @@
     {
       "hostname": "k[lps]*",
       "macaddress": "1C61B4*"
+    },
+    {
+      "hostname": "l5*",
+      "macaddress": "5CE931*"
+    },
+    {
+      "hostname": "p1*",
+      "macaddress": "482254*"
     }
   ],
   "documentation": "https://www.home-assistant.io/integrations/tplink",

--- a/homeassistant/generated/dhcp.py
+++ b/homeassistant/generated/dhcp.py
@@ -795,6 +795,16 @@ DHCP: list[dict[str, str | bool]] = [
         "macaddress": "1C61B4*",
     },
     {
+        "domain": "tplink",
+        "hostname": "l5*",
+        "macaddress": "5CE931*",
+    },
+    {
+        "domain": "tplink",
+        "hostname": "p1*",
+        "macaddress": "482254*",
+    },
+    {
         "domain": "tuya",
         "macaddress": "105A17*",
     },


### PR DESCRIPTION
This adds the mac address prefixes for P110 and L530. I left the hostname wildcards rather lax in hopes that other P1* and L5* devices share the same mac address space.