### PR TITLE
Add autodetection for L530, P110, and L900

### DIFF
--- a/homeassistant/components/tplink/manifest.json
+++ b/homeassistant/components/tplink/manifest.json
@@ -163,6 +163,18 @@
     {
       "hostname": "k[lps]*",
       "macaddress": "1C61B4*"
+    },
+    {
+      "hostname": "l5*",
+      "macaddress": "5CE931*"
+    },
+    {
+      "hostname": "p1*",
+      "macaddress": "482254*"
+    },
+    {
+      "hostname": "l9*",
+      "macaddress": "A842A1*"
     }
   ],
   "documentation": "https://www.home-assistant.io/integrations/tplink",

--- a/homeassistant/generated/dhcp.py
+++ b/homeassistant/generated/dhcp.py
@@ -799,6 +799,21 @@ DHCP: list[dict[str, str | bool]] = [
         "macaddress": "1C61B4*",
     },
     {
+        "domain": "tplink",
+        "hostname": "l5*",
+        "macaddress": "5CE931*",
+    },
+    {
+        "domain": "tplink",
+        "hostname": "p1*",
+        "macaddress": "482254*",
+    },
+    {
+        "domain": "tplink",
+        "hostname": "l9*",
+        "macaddress": "A842A1*",
+    },
+    {
         "domain": "tuya",
         "macaddress": "105A17*",
     },


### PR DESCRIPTION
This adds mac address prefixes for the devices I have, supersedes #2 
The wildcards are left quite lax assuming different series may share the same prefix.
